### PR TITLE
Voting event: Prioritize grabbing base Principal over any modded ones

### DIFF
--- a/BaldisBasicsPlusAdvanced/Game/Events/VotingEvent.cs
+++ b/BaldisBasicsPlusAdvanced/Game/Events/VotingEvent.cs
@@ -299,15 +299,17 @@ namespace BaldisBasicsPlusAdvanced.Game.Events
             }
         }
 
-        private static Principal GetPrincipal()
+        private Principal GetPrincipal()
         {
             Principal fallback = null;
-            foreach (NPC npc in BaseGameManager.Instance.Ec.Npcs)
+            foreach (NPC npc in ec.Npcs)
             {
-                if (npc is not Principal pri) continue;
-                fallback = pri;
-                if (pri.Character == Character.Principal)
-                    return pri;
+                if (!(npc is Principal)) continue;
+        
+                if (npc.Character == Character.Principal)
+                    return (Principal)npc;
+        
+                fallback = (Principal)npc;
             }
             return fallback;
         }

--- a/BaldisBasicsPlusAdvanced/Game/Events/VotingEvent.cs
+++ b/BaldisBasicsPlusAdvanced/Game/Events/VotingEvent.cs
@@ -299,6 +299,19 @@ namespace BaldisBasicsPlusAdvanced.Game.Events
             }
         }
 
+        private static Principal GetPrincipal()
+        {
+            Principal fallback = null;
+            foreach (NPC npc in BaseGameManager.Instance.Ec.Npcs)
+            {
+                if (npc is not Principal pri) continue;
+                fallback = pri;
+                if (pri.Character == Character.Principal)
+                    return pri;
+            }
+            return fallback;
+        }
+
         public override void Begin()
         {
             base.Begin();
@@ -320,7 +333,7 @@ namespace BaldisBasicsPlusAdvanced.Game.Events
 
             StartCoroutine(AttentionUpdater());
 
-            Principal principal = FindObjectOfType<Principal>();
+            Principal principal = GetPrincipal();
 
             if (principal != null)
             {


### PR DESCRIPTION
This prevents the event from picking NPCs that inherit the Principal's script as the one that patrols around the voting room (?), seen if you have Mr. Daycare in Recommended Characters Pack and the voting event in the same floor